### PR TITLE
Feature/poc service bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,17 @@ appsettings.Test.json
 /src/EPR.Payment.Facade.IntegrationTests/appsettings.json
 /src/TestResults
 *.csproj.user
+
+# Docker
+.env
+docker-compose.override.yml
+
+# JetBrains Rider
+*.sln.iml
+**/.idea/
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+

--- a/README.md
+++ b/README.md
@@ -158,17 +158,17 @@ appsettings.Development.json
 
 ### Running the Application
 1. Navigate to the project directory:
-    ```bash
-    cd \src\EPR.Payment.Facade
-    ```
- 
-2. To run the service locally:
+1. Start docker
+1. If you don't have one already, create a `.env` file in the root of the project. It should contain the sql password, in the form `SQL_PASSWORD=foobar`
+1. If you haven't pulled the docker images before, run
+   `docker compose -f docker-compose.yml pull`
+1. Run the docker containers
+   `docker compose --profile payments-stack -f docker-compose.yml up`
+1. To run the service locally:
     ```bash
     dotnet run
     ```
-
-3. Launch Browser:
-
+1. Launch Browser:
     Service Health Check:
     [https://localhost:7166/health](https://localhost:7166/health)
 

--- a/docker-compose-servicebus-config.json
+++ b/docker-compose-servicebus-config.json
@@ -1,0 +1,52 @@
+{
+    "UserConfig": {
+        "Namespaces": [
+            {
+                "Name": "sbemulatorns",
+                "Queues": [
+                    {
+                        "Name": "queue.1",
+                        "Properties": {
+                            "DeadLetteringOnMessageExpiration": false,
+                            "DefaultMessageTimeToLive": "PT1H",
+                            "DuplicateDetectionHistoryTimeWindow": "PT20S",
+                            "ForwardDeadLetteredMessagesTo": "",
+                            "ForwardTo": "",
+                            "LockDuration": "PT1M",
+                            "MaxDeliveryCount": 3,
+                            "RequiresDuplicateDetection": false,
+                            "RequiresSession": false
+                        }
+                    }
+                ],
+                "Topics": [
+                    {
+                        "Name": "topic.1",
+                        "Properties": {
+                            "DefaultMessageTimeToLive": "PT1H",
+                            "DuplicateDetectionHistoryTimeWindow": "PT20S",
+                            "RequiresDuplicateDetection": false
+                        },
+                        "Subscriptions": [
+                            {
+                                "Name": "subscription.1",
+                                "Properties": {
+                                    "DeadLetteringOnMessageExpiration": false,
+                                    "DefaultMessageTimeToLive": "PT1H",
+                                    "LockDuration": "PT1M",
+                                    "MaxDeliveryCount": 3,
+                                    "ForwardDeadLetteredMessagesTo": "",
+                                    "ForwardTo": "",
+                                    "RequiresSession": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "Logging": {
+            "Type": "File"
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+services:
+  
+  servicebus-emulator:
+    container_name: "payments-facade-servicebus-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
+    volumes:
+      - "./docker-compose-servicebus-config.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+      - "5300:5300"
+    environment:
+      SQL_SERVER: sql
+      MSSQL_SA_PASSWORD: "${SQL_PASSWORD}"  # Password should be same as what is set for SQL Edge  
+      ACCEPT_EULA: "Y"
+    depends_on:
+      sql:
+        condition: service_started
+    networks:
+      sb-emulator:
+        aliases:
+          - "sb-emulator"
+
+  sql:
+    container_name: payments-facade-sql
+    image: mcr.microsoft.com/azure-sql-edge
+    restart: always
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - "1433:1433"
+    networks:
+      sb-emulator:
+        aliases:
+          - "sql"
+    environment:
+      - ACCEPT_EULA=1
+      - SA_PASSWORD=${SQL_PASSWORD}
+
+networks:
+  sb-emulator:

--- a/src/EPR.Payment.Facade.Messaging/EPR.Payment.Facade.Messaging.csproj
+++ b/src/EPR.Payment.Facade.Messaging/EPR.Payment.Facade.Messaging.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/EPR.Payment.Facade.Messaging/FooMessage.cs
+++ b/src/EPR.Payment.Facade.Messaging/FooMessage.cs
@@ -1,0 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.Payment.Facade.Messaging;
+
+[ExcludeFromCodeCoverage]
+public record FooMessage(string Data1, string Data2);

--- a/src/EPR.Payment.Facade.Messaging/IServiceBusTopicPublisher.cs
+++ b/src/EPR.Payment.Facade.Messaging/IServiceBusTopicPublisher.cs
@@ -1,0 +1,6 @@
+namespace EPR.Payment.Facade.Messaging;
+
+public interface IServiceBusTopicPublisher
+{
+    Task SendMessage(FooMessage payload);
+}

--- a/src/EPR.Payment.Facade.Messaging/IServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Facade.Messaging/IServiceBusTopicSubscription.cs
@@ -1,0 +1,8 @@
+namespace EPR.Payment.Facade.Messaging;
+
+public interface IServiceBusTopicSubscription
+{
+    Task PrepareServiceBusSubscription();
+    Task CloseSubscriptionAsync();
+    ValueTask DisposeAsync();
+}

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicPublisher.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicPublisher.cs
@@ -10,10 +10,10 @@ namespace EPR.Payment.Facade.Messaging;
 [ExcludeFromCodeCoverage]
 public class ServiceBusTopicSender : IServiceBusTopicPublisher
 {
-    private const string TOPIC_PATH = "topic.new";
+    private const string TopicPath = "topic.new";
     private readonly ILogger<ServiceBusTopicSender> _logger;
     private readonly ServiceBusClient _client;
-    private Azure.Messaging.ServiceBus.ServiceBusSender? _clientSender;
+    private Azure.Messaging.ServiceBus.ServiceBusSender _clientSender = null!;
     private readonly string? _adminConnectionString;
 
     public ServiceBusTopicSender(ILogger<ServiceBusTopicSender> logger, IConfiguration configuration)
@@ -38,18 +38,17 @@ public class ServiceBusTopicSender : IServiceBusTopicPublisher
         }
         catch (Exception e)
         {
-            _logger.LogError(e.Message);
+            _logger.LogError(e, "Failed to send message: {messagePayload}", messagePayload);
         }
     }
 
-    [MemberNotNull(nameof(_clientSender))]
     private async Task SetupClient()
     {
         if (_clientSender == null)
         {
             var adminClient = new ServiceBusAdministrationClient(_adminConnectionString);
             
-            var topicExistsResult = await adminClient.TopicExistsAsync(TOPIC_PATH);
+            var topicExistsResult = await adminClient.TopicExistsAsync(TopicPath);
 
             if (!topicExistsResult.HasValue)
             {
@@ -59,10 +58,10 @@ public class ServiceBusTopicSender : IServiceBusTopicPublisher
             
             if (!topicExistsResult.Value)
             {
-                await adminClient.CreateTopicAsync(TOPIC_PATH);
+                await adminClient.CreateTopicAsync(TopicPath);
             }
 
-            _clientSender = _client.CreateSender(TOPIC_PATH);
+            _clientSender = _client.CreateSender(TopicPath);
         }
     }
 }

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicPublisher.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicPublisher.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace EPR.Payment.Facade.Messaging;
+
+[ExcludeFromCodeCoverage]
+public class ServiceBusTopicSender : IServiceBusTopicPublisher
+{
+    private const string TOPIC_PATH = "topic.new";
+    private readonly ILogger<ServiceBusTopicSender> _logger;
+    private readonly ServiceBusClient _client;
+    private Azure.Messaging.ServiceBus.ServiceBusSender? _clientSender;
+    private readonly string? _adminConnectionString;
+
+    public ServiceBusTopicSender(ILogger<ServiceBusTopicSender> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+ 
+        var connectionString = configuration.GetValue<string>("ServiceBus:ConnectionString");
+        _adminConnectionString = configuration.GetValue<string>("ServiceBus:AdminConnectionString");
+        _client = new ServiceBusClient(connectionString);
+    }
+ 
+    public async Task SendMessage(FooMessage payload)
+    {
+        await SetupClient();
+        string messagePayload = JsonSerializer.Serialize(payload);
+        var message = new ServiceBusMessage(messagePayload);
+ 
+        try
+        {
+            _logger.LogInformation("Sending message: {messagePayload}", messagePayload);
+            await _clientSender.SendMessageAsync(message);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message);
+        }
+    }
+
+    [MemberNotNull(nameof(_clientSender))]
+    private async Task SetupClient()
+    {
+        if (_clientSender == null)
+        {
+            var adminClient = new ServiceBusAdministrationClient(_adminConnectionString);
+            
+            var topicExistsResult = await adminClient.TopicExistsAsync(TOPIC_PATH);
+
+            if (!topicExistsResult.HasValue)
+            {
+                throw new InvalidOperationException(
+                    "Unable to get a result when trying to query for the existence of a topic");
+            }
+            
+            if (!topicExistsResult.Value)
+            {
+                await adminClient.CreateTopicAsync(TOPIC_PATH);
+            }
+
+            _clientSender = _client.CreateSender(TOPIC_PATH);
+        }
+    }
+}

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
@@ -9,12 +9,12 @@ namespace EPR.Payment.Facade.Messaging;
 [ExcludeFromCodeCoverage]
 public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
 {
-    private const string TOPIC_PATH = "topic.new";
-    private const string SUBSCRIPTION_NAME = "subscription.new";
+    private const string TopicPath = "topic.new";
+    private const string SubscriptionName = "subscription.new";
     private readonly ILogger<ServiceBusTopicSubscription> _logger;
     private readonly ServiceBusClient _client;
     private readonly ServiceBusAdministrationClient _adminClient;
-    private ServiceBusProcessor? _processor = null;
+    private ServiceBusProcessor? _processor;
  
     public ServiceBusTopicSubscription(ILogger<ServiceBusTopicSubscription> logger, IConfiguration configuration)
     {
@@ -28,43 +28,52 @@ public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
  
     public async Task PrepareServiceBusSubscription()
     {
-        var _serviceBusProcessorOptions = new ServiceBusProcessorOptions
+        var serviceBusProcessorOptions = new ServiceBusProcessorOptions
         {
             MaxConcurrentCalls = 1,
             AutoCompleteMessages = false,
         };
 
-        var topicExistsResult = await _adminClient.TopicExistsAsync(TOPIC_PATH);
-        
-        if (!topicExistsResult.HasValue)
+        try
         {
-            throw new InvalidOperationException(
-                "Unable to get a result when trying to query for the existence of a topic");
-        }
-        
-        if (!topicExistsResult.Value)
-        {
-            await _adminClient.CreateTopicAsync(TOPIC_PATH);
-        }
-        
-        var subscriptionExistsResult = await _adminClient.SubscriptionExistsAsync(TOPIC_PATH, SUBSCRIPTION_NAME);
+            var topicExistsResult = await _adminClient.TopicExistsAsync(TopicPath);
 
-        if (!subscriptionExistsResult.HasValue)
-        {
-            throw new InvalidOperationException(
-                "Unable to get a result when trying to query for the existence of a subscription");
+            if (!topicExistsResult.HasValue)
+            {
+                throw new InvalidOperationException(
+                    "Unable to get a result when trying to query for the existence of a topic");
+            }
+
+            if (!topicExistsResult.Value)
+            {
+                await _adminClient.CreateTopicAsync(TopicPath);
+            }
+
+            var subscriptionExistsResult = await _adminClient.SubscriptionExistsAsync(TopicPath, SubscriptionName);
+
+            if (!subscriptionExistsResult.HasValue)
+            {
+                throw new InvalidOperationException(
+                    "Unable to get a result when trying to query for the existence of a subscription");
+            }
+
+            if (!subscriptionExistsResult.Value)
+            {
+                await _adminClient.CreateSubscriptionAsync(TopicPath, SubscriptionName);
+            }
+
+            _processor = _client.CreateProcessor(TopicPath, SubscriptionName, serviceBusProcessorOptions);
+            _processor.ProcessMessageAsync += ProcessMessagesAsync;
+            _processor.ProcessErrorAsync += ProcessErrorAsync;
+
+            await _processor.StartProcessingAsync();
         }
-        if (!subscriptionExistsResult.Value)
+        catch (Exception ex)
         {
-            await _adminClient.CreateSubscriptionAsync(TOPIC_PATH, SUBSCRIPTION_NAME);
+            // we wouldn't have this exception catch for the live service. If the service cannot subscribe to the message bus, it shouldn't start
+            _logger.LogError(ex, "An exception occurred while starting up the service bus subscription");
         }
-        
-        _processor = _client.CreateProcessor(TOPIC_PATH, SUBSCRIPTION_NAME, _serviceBusProcessorOptions);
-        _processor.ProcessMessageAsync += ProcessMessagesAsync;
-        _processor.ProcessErrorAsync += ProcessErrorAsync;
-        
  
-        await _processor.StartProcessingAsync();
     }
  
     private async Task ProcessMessagesAsync(ProcessMessageEventArgs args)

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
@@ -22,8 +22,12 @@ public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
 
         var connectionString = configuration.GetValue<string>("ServiceBus:ConnectionString");
         var adminConnectionString = configuration.GetValue<string>("ServiceBus:AdminConnectionString");
-        _client = new ServiceBusClient(connectionString);
-        _adminClient = new ServiceBusAdministrationClient(adminConnectionString);
+
+        if (!string.IsNullOrEmpty(connectionString) && !string.IsNullOrEmpty(adminConnectionString))
+        {
+            _client = new ServiceBusClient(connectionString);
+            _adminClient = new ServiceBusAdministrationClient(adminConnectionString);
+        }
     }
  
     public async Task PrepareServiceBusSubscription()

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
@@ -12,8 +12,8 @@ public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
     private const string TopicPath = "topic.new";
     private const string SubscriptionName = "subscription.new";
     private readonly ILogger<ServiceBusTopicSubscription> _logger;
-    private readonly ServiceBusClient _client;
-    private readonly ServiceBusAdministrationClient _adminClient;
+    private readonly ServiceBusClient? _client;
+    private readonly ServiceBusAdministrationClient? _adminClient;
     private ServiceBusProcessor? _processor;
  
     public ServiceBusTopicSubscription(ILogger<ServiceBusTopicSubscription> logger, IConfiguration configuration)
@@ -40,6 +40,12 @@ public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
 
         try
         {
+            if (_adminClient is null || _client is null)
+            {
+                throw new InvalidOperationException(
+                    "Service bus client is null. Please check your connection strings.");
+            }
+            
             var topicExistsResult = await _adminClient.TopicExistsAsync(TopicPath);
 
             if (!topicExistsResult.HasValue)

--- a/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceBusTopicSubscription.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics.CodeAnalysis;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace EPR.Payment.Facade.Messaging;
+
+[ExcludeFromCodeCoverage]
+public class ServiceBusTopicSubscription : IServiceBusTopicSubscription
+{
+    private const string TOPIC_PATH = "topic.new";
+    private const string SUBSCRIPTION_NAME = "subscription.new";
+    private readonly ILogger<ServiceBusTopicSubscription> _logger;
+    private readonly ServiceBusClient _client;
+    private readonly ServiceBusAdministrationClient _adminClient;
+    private ServiceBusProcessor? _processor = null;
+ 
+    public ServiceBusTopicSubscription(ILogger<ServiceBusTopicSubscription> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+
+        var connectionString = configuration.GetValue<string>("ServiceBus:ConnectionString");
+        var adminConnectionString = configuration.GetValue<string>("ServiceBus:AdminConnectionString");
+        _client = new ServiceBusClient(connectionString);
+        _adminClient = new ServiceBusAdministrationClient(adminConnectionString);
+    }
+ 
+    public async Task PrepareServiceBusSubscription()
+    {
+        var _serviceBusProcessorOptions = new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = 1,
+            AutoCompleteMessages = false,
+        };
+
+        var topicExistsResult = await _adminClient.TopicExistsAsync(TOPIC_PATH);
+        
+        if (!topicExistsResult.HasValue)
+        {
+            throw new InvalidOperationException(
+                "Unable to get a result when trying to query for the existence of a topic");
+        }
+        
+        if (!topicExistsResult.Value)
+        {
+            await _adminClient.CreateTopicAsync(TOPIC_PATH);
+        }
+        
+        var subscriptionExistsResult = await _adminClient.SubscriptionExistsAsync(TOPIC_PATH, SUBSCRIPTION_NAME);
+
+        if (!subscriptionExistsResult.HasValue)
+        {
+            throw new InvalidOperationException(
+                "Unable to get a result when trying to query for the existence of a subscription");
+        }
+        if (!subscriptionExistsResult.Value)
+        {
+            await _adminClient.CreateSubscriptionAsync(TOPIC_PATH, SUBSCRIPTION_NAME);
+        }
+        
+        _processor = _client.CreateProcessor(TOPIC_PATH, SUBSCRIPTION_NAME, _serviceBusProcessorOptions);
+        _processor.ProcessMessageAsync += ProcessMessagesAsync;
+        _processor.ProcessErrorAsync += ProcessErrorAsync;
+        
+ 
+        await _processor.StartProcessingAsync();
+    }
+ 
+    private async Task ProcessMessagesAsync(ProcessMessageEventArgs args)
+    {
+        var myPayload = args.Message.Body.ToObjectFromJson<FooMessage>();
+        _logger.LogInformation("Received message: {myPayload}", myPayload);
+        await args.CompleteMessageAsync(args.Message);
+    }
+ 
+    private Task ProcessErrorAsync(ProcessErrorEventArgs arg)
+    {
+        _logger.LogError(arg.Exception, "Message handler encountered an exception");
+        _logger.LogDebug("- ErrorSource: {ErrorSource}", arg.ErrorSource);
+        _logger.LogDebug("- Entity Path: {EntityPath}", arg.EntityPath);
+        _logger.LogDebug("- FullyQualifiedNamespace: {FullyQualifiedNamespace}", arg.FullyQualifiedNamespace);
+ 
+        return Task.CompletedTask;
+    }
+ 
+    public async ValueTask DisposeAsync()
+    {
+        if (_processor != null)
+        {
+            await _processor.DisposeAsync();
+        }
+ 
+        if (_client != null)
+        {
+            await _client.DisposeAsync();
+        }
+    }
+ 
+    public async Task CloseSubscriptionAsync()
+    {
+        await _processor!.CloseAsync();
+    }
+}

--- a/src/EPR.Payment.Facade.Messaging/ServiceCollectionExtensions.cs
+++ b/src/EPR.Payment.Facade.Messaging/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EPR.Payment.Facade.Messaging;
+
+[ExcludeFromCodeCoverage]
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddMessaging(this IServiceCollection services)
+    {
+        services.AddSingleton<IServiceBusTopicPublisher, ServiceBusTopicSender>();
+        services.AddSingleton<IServiceBusTopicSubscription, ServiceBusTopicSubscription>();
+ 
+        services.AddHostedService<WorkerServiceBus>();
+        
+        return services;
+    }
+}

--- a/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
+++ b/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace EPR.Payment.Facade.Messaging;
+
+[ExcludeFromCodeCoverage]
+public class WorkerServiceBus : IHostedService, IDisposable
+{
+    private readonly ILogger<WorkerServiceBus> _logger;
+    private readonly IServiceBusTopicSubscription _serviceBusTopicSubscription;
+ 
+    public WorkerServiceBus(IServiceBusTopicSubscription serviceBusTopicSubscription,
+        ILogger<WorkerServiceBus> logger)
+    {
+        _serviceBusTopicSubscription = serviceBusTopicSubscription;
+        _logger = logger;
+    }
+ 
+    public async Task StartAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogDebug("Starting the service bus queue consumer and the subscription");
+        await _serviceBusTopicSubscription.PrepareServiceBusSubscription().ConfigureAwait(false);
+    }
+ 
+    public async Task StopAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogDebug("Stopping the service bus queue consumer and the subscription");
+        await _serviceBusTopicSubscription.CloseSubscriptionAsync().ConfigureAwait(false);
+    }
+ 
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+ 
+    protected virtual async void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            await _serviceBusTopicSubscription.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
+++ b/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
@@ -17,13 +17,13 @@ public class WorkerServiceBus : IHostedService, IDisposable
         _logger = logger;
     }
  
-    public async Task StartAsync(CancellationToken stoppingToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         _logger.LogDebug("Starting the service bus queue consumer and the subscription");
         await _serviceBusTopicSubscription.PrepareServiceBusSubscription().ConfigureAwait(false);
     }
  
-    public async Task StopAsync(CancellationToken stoppingToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         _logger.LogDebug("Stopping the service bus queue consumer and the subscription");
         await _serviceBusTopicSubscription.CloseSubscriptionAsync().ConfigureAwait(false);

--- a/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
+++ b/src/EPR.Payment.Facade.Messaging/WorkerServiceBus.cs
@@ -19,14 +19,16 @@ public class WorkerServiceBus : IHostedService, IDisposable
  
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Starting the service bus queue consumer and the subscription");
+        _logger.LogInformation("Starting the service bus queue consumer and the subscription");
         await _serviceBusTopicSubscription.PrepareServiceBusSubscription().ConfigureAwait(false);
+        _logger.LogInformation("Service bus queue consumer started");
     }
  
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Stopping the service bus queue consumer and the subscription");
+        _logger.LogInformation("Stopping the service bus queue consumer and the subscription");
         await _serviceBusTopicSubscription.CloseSubscriptionAsync().ConfigureAwait(false);
+        _logger.LogInformation("Service bus queue consumer stopped");
     }
  
     public void Dispose()
@@ -37,6 +39,7 @@ public class WorkerServiceBus : IHostedService, IDisposable
  
     protected virtual async void Dispose(bool disposing)
     {
+        _logger.LogInformation("Disposing of the worker service");
         if (disposing)
         {
             await _serviceBusTopicSubscription.DisposeAsync().ConfigureAwait(false);

--- a/src/EPR.Payment.Facade.sln
+++ b/src/EPR.Payment.Facade.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.runsettings = .runsettings
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EPR.Payment.Facade.Messaging", "EPR.Payment.Facade.Messaging\EPR.Payment.Facade.Messaging.csproj", "{287A2972-8048-479A-B826-356835D47A4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{4820924E-D48A-4F6F-BFB3-02122B43296F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4820924E-D48A-4F6F-BFB3-02122B43296F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4820924E-D48A-4F6F-BFB3-02122B43296F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{287A2972-8048-479A-B826-356835D47A4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{287A2972-8048-479A-B826-356835D47A4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{287A2972-8048-479A-B826-356835D47A4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{287A2972-8048-479A-B826-356835D47A4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EPR.Payment.Facade/Controllers/Messaging/MessagingController.cs
+++ b/src/EPR.Payment.Facade/Controllers/Messaging/MessagingController.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+using EPR.Payment.Facade.Messaging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EPR.Payment.Facade.Controllers.Messaging;
+
+[ExcludeFromCodeCoverage]
+[ApiController]
+[Route("api/")]
+public class MessagingController(IServiceBusTopicPublisher publisher) : ControllerBase
+{
+    [HttpPost("test")]
+    public async Task<IActionResult> PublishTestMessage(string data1, string data2)
+    {
+        var message = new FooMessage(data1, data2);
+        await publisher.SendMessage(message);
+        return NoContent(); 
+    }
+}

--- a/src/EPR.Payment.Facade/Controllers/Messaging/MessagingController.cs
+++ b/src/EPR.Payment.Facade/Controllers/Messaging/MessagingController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using EPR.Payment.Facade.Messaging;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EPR.Payment.Facade.Controllers.Messaging;
@@ -7,6 +8,7 @@ namespace EPR.Payment.Facade.Controllers.Messaging;
 [ExcludeFromCodeCoverage]
 [ApiController]
 [Route("api/")]
+[AllowAnonymous]
 public class MessagingController(IServiceBusTopicPublisher publisher) : ControllerBase
 {
     [HttpPost("test")]

--- a/src/EPR.Payment.Facade/Dockerfile
+++ b/src/EPR.Payment.Facade/Dockerfile
@@ -20,10 +20,12 @@ ENV PATH="${PATH}:/root/.dotnet/tools"
 WORKDIR /src
 COPY ["EPR.Payment.Facade/EPR.Payment.Facade.csproj", "EPR.Payment.Facade/"]
 COPY ["EPR.Payment.Facade.Common/EPR.Payment.Facade.Common.csproj", "EPR.Payment.Facade.Common/"]
+COPY ["EPR.Payment.Facade.Messaging/EPR.Payment.Facade.Messaging.csproj", "EPR.Payment.Facade.Messaging/"]
 RUN dotnet restore "EPR.Payment.Facade/EPR.Payment.Facade.csproj"
 
 COPY EPR.Payment.Facade/. ./EPR.Payment.Facade/.
 COPY EPR.Payment.Facade.Common/. ./EPR.Payment.Facade.Common/.
+COPY EPR.Payment.Facade.Messaging/. ./EPR.Payment.Facade.Messaging/.
 
 WORKDIR "/src/EPR.Payment.Facade"
 RUN dotnet build "EPR.Payment.Facade.csproj" -c Release /p:AzureBuild=true -o /app/build

--- a/src/EPR.Payment.Facade/EPR.Payment.Facade.csproj
+++ b/src/EPR.Payment.Facade/EPR.Payment.Facade.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\EPR.Payment.Facade.Common\EPR.Payment.Facade.Common.csproj" />
+    <ProjectReference Include="..\EPR.Payment.Facade.Messaging\EPR.Payment.Facade.Messaging.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.Payment.Facade/Program.cs
+++ b/src/EPR.Payment.Facade/Program.cs
@@ -4,6 +4,7 @@ using EPR.Payment.Facade.Common.Configuration;
 using EPR.Payment.Facade.Extension;
 using EPR.Payment.Facade.HealthCheck;
 using EPR.Payment.Facade.Helpers;
+using EPR.Payment.Facade.Messaging;
 using EPR.Payment.Facade.Validations.Payments;
 using EPR.Payment.Facade.Validations.RegistrationFees.Producer;
 using FluentValidation.AspNetCore;
@@ -37,6 +38,8 @@ builder.Services.AddFluentValidation(fv =>
     fv.AutomaticValidationEnabled = false;
 });
 builder.Services.Configure<OnlinePaymentServiceOptions>(builder.Configuration.GetSection("PaymentServiceOptions"));
+
+builder.Services.AddMessaging();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(setupAction =>

--- a/src/EPR.Payment.Facade/appsettings.json
+++ b/src/EPR.Payment.Facade/appsettings.json
@@ -29,5 +29,9 @@
     "EnableReprocessorOrExporterRegistrationFeesCalculation": true,
     "EnableReprocessorOrExporterAccreditationFeesFeature": true,
     "EnableReprocessorOrExporterAccreditationFeesCalculation": true
+  },
+  "ServiceBus": {
+    "ConnectionString": "",
+    "AdminConnectionString": ""
   }
 }


### PR DESCRIPTION
This POC demonstrates subscribing to the azure service bus from a background task, running as a Hosted Service. It tests whether or not the service has the ability to create topics and subscriptions, and then publish and consume messages.

<img width="730" height="298" alt="image" src="https://github.com/user-attachments/assets/94be6f18-3943-4903-9d10-d9efbfd34fc0" />

After deployment, you must create two environment variables in the app service, and then restart the service. These are `ServiceBus__AdminConnectionString` and `ServiceBus__ConnectionString`. The value should point to the `ServiceBusConnectionString` secret in the key vault. On restarting the service, the log stream will show whether topics and subscriptions are created or not. A test REST api endpoint has also been created. Posting to that endpoint results in a message being published and also consumed - this should show in the log stream.