### PR TITLE
SUB-299 Upgrade solution to .NET 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ appsettings.Test.json
 /obj
 /src/EPR.Payment.Facade/appsettings.Development.json
 /src/EPR.Payment.Facade.IntegrationTests/appsettings.json
+/src/EPR.Payment.Facade.IntegrationTests/appsettings.Development.json
 /src/TestResults
 *.csproj.user

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -16,7 +16,7 @@ parameters:
     - 'SonarQube'
     # - 'SonarQubeLatest'
     
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml
@@ -35,7 +35,7 @@ variables:
   - name: runTests
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
 resources:
   repositories:

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 

--- a/src/EPR.Payment.Facade.Common.UnitTests/EPR.Payment.Facade.Common.UnitTests.csproj
+++ b/src/EPR.Payment.Facade.Common.UnitTests/EPR.Payment.Facade.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -34,17 +34,15 @@
 	</PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="Polly" Version="8.4.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.Payment.Facade.Common/EPR.Payment.Facade.Common.csproj
+++ b/src/EPR.Payment.Facade.Common/EPR.Payment.Facade.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,13 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.4.1" />
   </ItemGroup>

--- a/src/EPR.Payment.Facade.IntegrationTests/EPR.Payment.Facade.Common.IntegrationTests.csproj
+++ b/src/EPR.Payment.Facade.IntegrationTests/EPR.Payment.Facade.Common.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -21,10 +21,10 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
@@ -40,6 +40,9 @@
 
   <ItemGroup>
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/EPR.Payment.Facade.UnitTests/EPR.Payment.Facade.UnitTests.csproj
+++ b/src/EPR.Payment.Facade.UnitTests/EPR.Payment.Facade.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<NoWarn>CA1806;CS8625</NoWarn>
@@ -34,13 +34,11 @@
 	</PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.Payment.Facade.sln.DotSettings.user
+++ b/src/EPR.Payment.Facade.sln.DotSettings.user
@@ -1,8 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=7ff871f9_002D930e_002D4f6f_002D8929_002D26c56382fd5a/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Or&gt;&#xD;
-    &lt;Project Location="C:\Repos\epr-payment-facade\src\EPR.Payment.Facade.UnitTests" Presentation="&amp;lt;Tests&amp;gt;\&amp;lt;EPR.Payment.Facade.UnitTests&amp;gt;" /&gt;&#xD;
-    &lt;Project Location="C:\Repos\epr-payment-facade\src\EPR.Payment.Facade.Common.UnitTests" Presentation="&amp;lt;Tests&amp;gt;\&amp;lt;EPR.Payment.Facade.Common.UnitTests&amp;gt;" /&gt;&#xD;
-    &lt;Project Location="C:\Repos\epr-payment-facade\src\EPR.Payment.Facade.IntegrationTests" Presentation="&amp;lt;Tests&amp;gt;\&amp;lt;EPR.Payment.Facade.Common.IntegrationTests&amp;gt;" /&gt;&#xD;
-  &lt;/Or&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/src/EPR.Payment.Facade/Dockerfile
+++ b/src/EPR.Payment.Facade/Dockerfile
@@ -1,4 +1,4 @@
-FROM defradigital/dotnetcore-development:dotnet8.0 AS base
+FROM defradigital/dotnetcore-development:dotnet10.0 AS base
 
 USER root
 ARG PORT=8080
@@ -8,7 +8,7 @@ EXPOSE ${PORT}
 RUN apk update && apk --no-cache add icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0
 
-FROM defradigital/dotnetcore-development:dotnet8.0 AS build
+FROM defradigital/dotnetcore-development:dotnet10.0 AS build
 USER root
 
 # Install dotnet-ef tool

--- a/src/EPR.Payment.Facade/EPR.Payment.Facade.csproj
+++ b/src/EPR.Payment.Facade/EPR.Payment.Facade.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>4fa158e2-8221-4662-9320-6315ede7f154</UserSecretsId>
@@ -28,16 +28,12 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.1.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.14.1" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.15.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />

--- a/src/EPR.Payment.Facade/Program.cs
+++ b/src/EPR.Payment.Facade/Program.cs
@@ -130,9 +130,8 @@ builder.Services.AddApplicationInsightsTelemetry(options => { options.EnableAdap
 builder.Services.AddLogging();
 
 // Conditional Authentication based on Feature Flag
-using var serviceProvider = builder.Services.BuildServiceProvider();
-var featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
-if (await featureManager.IsEnabledAsync("EnableAuthenticationFeature"))
+var enableAuthenticationFeature = builder.Configuration.GetValue<bool>("FeatureManagement:EnableAuthenticationFeature");
+if (enableAuthenticationFeature)
 {
     // Authentication
     builder.Services
@@ -147,7 +146,7 @@ if (await featureManager.IsEnabledAsync("EnableAuthenticationFeature"))
                 builder.Configuration.Bind(Constants.AzureAdB2C, options);
             });
 
-    
+
     builder.Services.AddAuthorizationBuilder().AddFallbackPolicy("EprPaymentFallBackPolicy", new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .Build());
@@ -156,6 +155,7 @@ if (await featureManager.IsEnabledAsync("EnableAuthenticationFeature"))
 var app = builder.Build();
 
 var logger = app.Services.GetRequiredService<ILogger<Program>>();
+var featureManager = app.Services.GetRequiredService<IFeatureManager>();
 
 bool enableOnlinePaymentsFeature = await featureManager.IsEnabledAsync("EnableOnlinePaymentsFeature");
 bool enablePaymentInitiation = await featureManager.IsEnabledAsync("EnablePaymentInitiation");
@@ -196,7 +196,7 @@ app.UseRouting();
 app.UseCors("AllowAll");
 
 // Conditionally apply Authentication and Authorization
-if (await featureManager.IsEnabledAsync("EnableAuthenticationFeature"))
+if (enableAuthenticationFeature)
 {
     app.UseAuthentication();
     app.UseAuthorization();


### PR DESCRIPTION
- Remove packages provided by the shared framework (NU1510) from EPR.Payment.Facade, EPR.Payment.Facade.UnitTests, and EPR.Payment.Facade.Common.UnitTests
- Bump Microsoft.Identity.Web 3.14.1 -> 3.15.1 to pull in patched System.Security.Cryptography.Xml 9.0.15 (fixes NU1903)
- Resolve ASP0000 in Program.cs: read  EnableAuthenticationFeature from configuration before Build(); resolve IFeatureManager from app.Services afterwards, avoiding a premature BuildServiceProvider()
- Add local appsettings.Development.json for integration tests (gitignored) and copy it to output at build time
- Moved the build and deployment pipelines to the new build agents and changed the parameter to .NET10 to indicate the use of the .NET 10 SDK