### PR TITLE
Feature/sub 317 move calc to payment service

### DIFF
--- a/src/EPR.Payment.Facade.Common.UnitTests/RestServices/HttpComplianceSchemeFeesServiceTests.cs
+++ b/src/EPR.Payment.Facade.Common.UnitTests/RestServices/HttpComplianceSchemeFeesServiceTests.cs
@@ -370,5 +370,103 @@ namespace EPR.Payment.Facade.Common.UnitTests.RESTServices
                     ItExpr.IsAny<CancellationToken>());
             }
         }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ValidRequest_ReturnsResponseDto(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpComplianceSchemeFeesService httpComplianceSchemeFeesService,
+            CancellationToken cancellationToken)
+        {
+            // Arrange
+            var submissionId = Guid.NewGuid();
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ReturnsAsync(new HttpResponseMessage
+                       {
+                           StatusCode = HttpStatusCode.OK,
+                           Content = new StringContent(JsonConvert.SerializeObject(_complianceSchemeFeesResponseDto), Encoding.UTF8, "application/json")
+                       });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpComplianceSchemeFeesService = CreateHttpComplianceSchemeFeesService(httpClient);
+
+            // Act
+            var result = await httpComplianceSchemeFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(_complianceSchemeFeesResponseDto);
+                handlerMock.Protected().Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(msg =>
+                        msg.Method == HttpMethod.Get
+                        && msg.RequestUri!.ToString().EndsWith($"compliance-scheme/registration-fee/{submissionId}")),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturns404_ReturnsNull(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpComplianceSchemeFeesService httpComplianceSchemeFeesService,
+            CancellationToken cancellationToken)
+        {
+            // Arrange
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ReturnsAsync(new HttpResponseMessage
+                       {
+                           StatusCode = HttpStatusCode.NotFound,
+                           Content = new StringContent(string.Empty),
+                       });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpComplianceSchemeFeesService = CreateHttpComplianceSchemeFeesService(httpClient);
+
+            // Act
+            var result = await httpComplianceSchemeFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_HttpRequestException_ThrowsServiceException(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpComplianceSchemeFeesService httpComplianceSchemeFeesService,
+            CancellationToken cancellationToken)
+        {
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ThrowsAsync(new HttpRequestException("boom"));
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpComplianceSchemeFeesService = CreateHttpComplianceSchemeFeesService(httpClient);
+
+            Func<Task> act = async () => await httpComplianceSchemeFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            await act.Should().ThrowAsync<ServiceException>();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_UnexpectedException_ThrowsServiceException(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpComplianceSchemeFeesService httpComplianceSchemeFeesService,
+            CancellationToken cancellationToken)
+        {
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ThrowsAsync(new Exception("oops"));
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpComplianceSchemeFeesService = CreateHttpComplianceSchemeFeesService(httpClient);
+
+            Func<Task> act = async () => await httpComplianceSchemeFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            await act.Should().ThrowAsync<ServiceException>()
+                .WithMessage("An unexpected error occurred while calculating Compliance Scheme fees.");
+        }
     }
 }

--- a/src/EPR.Payment.Facade.Common.UnitTests/RestServices/HttpProducerFeesServiceTests.cs
+++ b/src/EPR.Payment.Facade.Common.UnitTests/RestServices/HttpProducerFeesServiceTests.cs
@@ -368,5 +368,103 @@ namespace EPR.Payment.Facade.Common.UnitTests.RESTServices
                     ItExpr.IsAny<CancellationToken>());
             }
         }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ValidRequest_ReturnsResponseDto(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpProducerFeesService httpProducerFeesService,
+            CancellationToken cancellationToken)
+        {
+            // Arrange
+            var submissionId = Guid.NewGuid();
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ReturnsAsync(new HttpResponseMessage
+                       {
+                           StatusCode = HttpStatusCode.OK,
+                           Content = new StringContent(JsonConvert.SerializeObject(_producerFeesResponseDto), Encoding.UTF8, "application/json")
+                       });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpProducerFeesService = CreateHttpProducerFeesService(httpClient);
+
+            // Act
+            var result = await httpProducerFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().BeEquivalentTo(_producerFeesResponseDto);
+                handlerMock.Protected().Verify(
+                    "SendAsync",
+                    Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(msg =>
+                        msg.Method == HttpMethod.Get
+                        && msg.RequestUri!.ToString().EndsWith($"producer/registration-fee/{submissionId}")),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturns404_ReturnsNull(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpProducerFeesService httpProducerFeesService,
+            CancellationToken cancellationToken)
+        {
+            // Arrange
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ReturnsAsync(new HttpResponseMessage
+                       {
+                           StatusCode = HttpStatusCode.NotFound,
+                           Content = new StringContent(string.Empty),
+                       });
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpProducerFeesService = CreateHttpProducerFeesService(httpClient);
+
+            // Act
+            var result = await httpProducerFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_HttpRequestException_ThrowsServiceException(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpProducerFeesService httpProducerFeesService,
+            CancellationToken cancellationToken)
+        {
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ThrowsAsync(new HttpRequestException("boom"));
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpProducerFeesService = CreateHttpProducerFeesService(httpClient);
+
+            Func<Task> act = async () => await httpProducerFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            await act.Should().ThrowAsync<ServiceException>();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_UnexpectedException_ThrowsServiceException(
+            [Frozen] Mock<HttpMessageHandler> handlerMock,
+            HttpProducerFeesService httpProducerFeesService,
+            CancellationToken cancellationToken)
+        {
+            handlerMock.Protected()
+                       .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                       .ThrowsAsync(new Exception("oops"));
+
+            var httpClient = new HttpClient(handlerMock.Object);
+            httpProducerFeesService = CreateHttpProducerFeesService(httpClient);
+
+            Func<Task> act = async () => await httpProducerFeesService.GetFeesBySubmissionAsync(Guid.NewGuid(), cancellationToken);
+
+            await act.Should().ThrowAsync<ServiceException>()
+                .WithMessage(ExceptionMessages.UnexpectedErrorCalculatingProducerFees);
+        }
     }
 }

--- a/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesResponseDto.cs
+++ b/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesResponseDto.cs
@@ -9,6 +9,7 @@ namespace EPR.Payment.Facade.Common.Dtos.Response.RegistrationFees.ComplianceSch
         public decimal PreviousPayment { get; set; }
         public decimal OutstandingPayment { get; set; }
         public List<ComplianceSchemeMembersWithFeesDto> ComplianceSchemeMembersWithFees { get; set; } = new();
+        public string? RegistrationBlobName { get; set; }
     }
 
     public class ComplianceSchemeMembersWithFeesDto

--- a/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationFees/Producer/ProducerFeesResponseDto.cs
+++ b/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationFees/Producer/ProducerFeesResponseDto.cs
@@ -11,5 +11,6 @@
         public decimal PreviousPayment { get; set; }
         public decimal OutstandingPayment { get; set; }
         public required SubsidiariesFeeBreakdown SubsidiariesFeeBreakdown { get; set; }
+        public string? RegistrationBlobName { get; set; }
     }
 }

--- a/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationSubmission/RegistrationFeeCalculationDetailsDto.cs
+++ b/src/EPR.Payment.Facade.Common/Dtos/Response/RegistrationSubmission/RegistrationFeeCalculationDetailsDto.cs
@@ -22,5 +22,7 @@ namespace EPR.Payment.Facade.Common.Dtos.Response.RegistrationSubmission
         public bool IsNewJoiner { get; set; }
 
         public int NationId { get; set; }
+
+        public string? RegistrationBlobName { get; set; }
     }
 }

--- a/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/ComplianceScheme/HttpComplianceSchemeFeesService.cs
+++ b/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/ComplianceScheme/HttpComplianceSchemeFeesService.cs
@@ -50,5 +50,27 @@ namespace EPR.Payment.Facade.Common.RESTServices.RegistrationFees.ComplianceSche
                 throw new ServiceException(ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees, ex);
             }
         }
+
+        public async Task<ComplianceSchemeFeesResponseDto?> GetFeesBySubmissionAsync(
+            Guid submissionId, CancellationToken cancellationToken = default)
+        {
+            var url = $"{UrlConstants.CalculateComplianceSchemeFee}/{submissionId}";
+            try
+            {
+                return await Get<ComplianceSchemeFeesResponseDto>(url, cancellationToken, includeTrailingSlash: false);
+            }
+            catch (ResponseCodeException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new ServiceException(ExceptionMessages.ErrorCalculatingComplianceSchemeFees, ex);
+            }
+            catch (Exception ex)
+            {
+                throw new ServiceException(ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees, ex);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/ComplianceScheme/Interfaces/IHttpComplianceSchemeFeesService.cs
+++ b/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/ComplianceScheme/Interfaces/IHttpComplianceSchemeFeesService.cs
@@ -6,5 +6,7 @@ namespace EPR.Payment.Facade.Common.RESTServices.RegistrationFees.ComplianceSche
     public interface IHttpComplianceSchemeFeesService
     {
         Task<ComplianceSchemeFeesResponseDto> CalculateFeesAsync(ComplianceSchemeFeesRequestDto request, CancellationToken cancellationToken = default);
+
+        Task<ComplianceSchemeFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/Producer/HttpProducerFeesService.cs
+++ b/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/Producer/HttpProducerFeesService.cs
@@ -46,5 +46,27 @@ namespace EPR.Payment.Facade.Common.RESTServices.RegistrationFees
                 throw new ServiceException(ExceptionMessages.ErrorCalculatingProducerFees, ex);
             }
         }
+
+        public async Task<ProducerFeesResponseDto?> GetFeesBySubmissionAsync(
+            Guid submissionId, CancellationToken cancellationToken = default)
+        {
+            var url = $"{UrlConstants.CalculateProducerRegistrationFees}/{submissionId}";
+            try
+            {
+                return await Get<ProducerFeesResponseDto>(url, cancellationToken, includeTrailingSlash: false);
+            }
+            catch (ResponseCodeException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new ServiceException(ExceptionMessages.ErrorCalculatingProducerFees, ex);
+            }
+            catch (Exception ex)
+            {
+                throw new ServiceException(ExceptionMessages.UnexpectedErrorCalculatingProducerFees, ex);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/Producer/Interfaces/IHttpProducerFeesService.cs
+++ b/src/EPR.Payment.Facade.Common/RESTServices/RegistrationFees/Producer/Interfaces/IHttpProducerFeesService.cs
@@ -6,5 +6,7 @@ namespace EPR.Payment.Facade.Common.RESTServices.RegistrationFees.Producer.Inter
     public interface IHttpProducerFeesService
     {
         Task<ProducerFeesResponseDto> CalculateProducerFeesAsync(ProducerFeesRequestDto request, CancellationToken cancellationToken = default);
+
+        Task<ProducerFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EPR.Payment.Facade.UnitTests/Controllers/RegistrationFees/ComplianceSchemeFeesControllerTests.cs
+++ b/src/EPR.Payment.Facade.UnitTests/Controllers/RegistrationFees/ComplianceSchemeFeesControllerTests.cs
@@ -239,5 +239,82 @@ namespace EPR.Payment.Facade.UnitTests.Controllers.RegistrationFees
                 problemDetails?.Detail.Should().Be(ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees);
             }
         }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturnsDto_ReturnsOk(
+            [Frozen] Mock<IComplianceSchemeCalculatorService> serviceMock,
+            [Greedy] ComplianceSchemeFeesController controller,
+            [Frozen] ComplianceSchemeFeesResponseDto expected)
+        {
+            var submissionId = Guid.NewGuid();
+            serviceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            using (new AssertionScope())
+            {
+                result.Should().BeOfType<OkObjectResult>();
+                (result as OkObjectResult)!.Value.Should().Be(expected);
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturnsNull_ReturnsNotFound(
+            [Frozen] Mock<IComplianceSchemeCalculatorService> serviceMock,
+            [Greedy] ComplianceSchemeFeesController controller)
+        {
+            var submissionId = Guid.NewGuid();
+            serviceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ComplianceSchemeFeesResponseDto?)null);
+
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceThrowsServiceException_Returns500WithServiceErrorTitle(
+            [Frozen] Mock<IComplianceSchemeCalculatorService> serviceMock,
+            [Greedy] ComplianceSchemeFeesController controller)
+        {
+            var submissionId = Guid.NewGuid();
+            serviceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ServiceException("service is down"));
+
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            using (new AssertionScope())
+            {
+                result.Should().BeOfType<ObjectResult>();
+                var objectResult = result as ObjectResult;
+                var problemDetails = objectResult?.Value as ProblemDetails;
+                objectResult?.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+                problemDetails?.Title.Should().Be("Service Error");
+                problemDetails?.Detail.Should().Be("service is down");
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceThrowsUnexpected_Returns500WithUnexpectedErrorTitle(
+            [Frozen] Mock<IComplianceSchemeCalculatorService> serviceMock,
+            [Greedy] ComplianceSchemeFeesController controller)
+        {
+            var submissionId = Guid.NewGuid();
+            serviceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("boom"));
+
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            using (new AssertionScope())
+            {
+                result.Should().BeOfType<ObjectResult>();
+                var objectResult = result as ObjectResult;
+                var problemDetails = objectResult?.Value as ProblemDetails;
+                objectResult?.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+                problemDetails?.Title.Should().Be("Unexpected Error");
+                problemDetails?.Detail.Should().Be(ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade.UnitTests/Controllers/RegistrationFees/ProducersFeesControllerTests.cs
+++ b/src/EPR.Payment.Facade.UnitTests/Controllers/RegistrationFees/ProducersFeesControllerTests.cs
@@ -243,5 +243,81 @@ namespace EPR.Payment.Facade.UnitTests.Controllers
             act.Should().Throw<ArgumentNullException>()
                 .WithParameterName("registrationValidator");
         }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturnsResponse_ReturnsOk(
+            [Frozen] Mock<IProducerFeesService> producerFeesServiceMock,
+            [Greedy] ProducersFeesController controller,
+            [Frozen] ProducerFeesResponseDto expectedResponse)
+        {
+            // Arrange
+            var submissionId = Guid.NewGuid();
+            producerFeesServiceMock
+                .Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResponse);
+
+            // Act
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+                ok.Value.Should().BeEquivalentTo(expectedResponse);
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceReturnsNull_ReturnsNotFound(
+            [Frozen] Mock<IProducerFeesService> producerFeesServiceMock,
+            [Greedy] ProducersFeesController controller)
+        {
+            var submissionId = Guid.NewGuid();
+            producerFeesServiceMock
+                .Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProducerFeesResponseDto?)null);
+
+            var result = await controller.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceThrowsServiceException_Returns500(
+            [Frozen] Mock<IProducerFeesService> producerFeesServiceMock,
+            [Greedy] ProducersFeesController controller)
+        {
+            producerFeesServiceMock
+                .Setup(s => s.GetFeesBySubmissionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ServiceException("boom"));
+
+            var result = await controller.GetFeesBySubmissionAsync(Guid.NewGuid(), CancellationToken.None);
+
+            using (new AssertionScope())
+            {
+                var status = result.Should().BeOfType<ObjectResult>().Subject;
+                status.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_ServiceThrowsUnexpectedException_Returns500(
+            [Frozen] Mock<IProducerFeesService> producerFeesServiceMock,
+            [Greedy] ProducersFeesController controller)
+        {
+            producerFeesServiceMock
+                .Setup(s => s.GetFeesBySubmissionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("oops"));
+
+            var result = await controller.GetFeesBySubmissionAsync(Guid.NewGuid(), CancellationToken.None);
+
+            using (new AssertionScope())
+            {
+                var status = result.Should().BeOfType<ObjectResult>().Subject;
+                status.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+                var problem = status.Value.Should().BeOfType<ProblemDetails>().Subject;
+                problem.Detail.Should().Be(ExceptionMessages.UnexpectedErrorCalculatingProducerFees);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade.UnitTests/Services/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesServiceTests.cs
+++ b/src/EPR.Payment.Facade.UnitTests/Services/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesServiceTests.cs
@@ -130,5 +130,70 @@ namespace EPR.Payment.Facade.UnitTests.Services.RegistrationFees.ComplianceSchem
                 thrownException.Which.Message.Should().Be(exceptionMessage);
             }
         }
+
+        [TestMethod, AutoMoqData]
+        public async Task GetFeesBySubmissionAsync_HttpServiceReturnsDto_ReturnsDto(
+            ComplianceSchemeFeesResponseDto expectedResponse)
+        {
+            var submissionId = Guid.NewGuid();
+            _httpComplianceSchemeFeesServiceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResponse);
+
+            var result = await _service.GetFeesBySubmissionAsync(submissionId);
+
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceReturnsNull_ReturnsNull()
+        {
+            var submissionId = Guid.NewGuid();
+            _httpComplianceSchemeFeesServiceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ComplianceSchemeFeesResponseDto?)null);
+
+            var result = await _service.GetFeesBySubmissionAsync(submissionId);
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceThrowsServiceException_RethrowsAsIs()
+        {
+            var submissionId = Guid.NewGuid();
+            var serviceException = new ServiceException("http-layer service error");
+            _httpComplianceSchemeFeesServiceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(serviceException);
+
+            Func<Task> act = () => _service.GetFeesBySubmissionAsync(submissionId);
+
+            (await act.Should().ThrowAsync<ServiceException>())
+                .Which.Should().BeSameAs(serviceException);
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceThrowsUnexpectedException_LogsAndWraps()
+        {
+            var submissionId = Guid.NewGuid();
+            var exception = new InvalidOperationException("boom");
+            _httpComplianceSchemeFeesServiceMock.Setup(s => s.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(exception);
+
+            Func<Task> act = () => _service.GetFeesBySubmissionAsync(submissionId);
+
+            using (new AssertionScope())
+            {
+                var thrown = await act.Should().ThrowAsync<ServiceException>()
+                    .WithMessage(ExceptionMessages.ErrorCalculatingComplianceSchemeFees);
+                thrown.Which.InnerException.Should().BeSameAs(exception);
+                _loggerMock.Verify(
+                    x => x.Log(
+                        LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees)),
+                        exception,
+                        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                    Times.Once);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade.UnitTests/Services/RegistrationFees/Producer/ProducerFeesServiceTests.cs
+++ b/src/EPR.Payment.Facade.UnitTests/Services/RegistrationFees/Producer/ProducerFeesServiceTests.cs
@@ -140,5 +140,58 @@ namespace EPR.Payment.Facade.UnitTests.Services.RegistrationFees.Producer
                 thrownException.Which.Message.Should().Be(exceptionMessage);
             }
         }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceReturnsResponse_PassesThrough()
+        {
+            var submissionId = Guid.NewGuid();
+            var expected = _fixture.Create<ProducerFeesResponseDto>();
+            _httpProducerFeesService
+                .Setup(h => h.GetFeesBySubmissionAsync(submissionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+
+            var result = await _service.GetFeesBySubmissionAsync(submissionId, CancellationToken.None);
+
+            result.Should().BeSameAs(expected);
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceReturnsNull_ReturnsNull()
+        {
+            _httpProducerFeesService
+                .Setup(h => h.GetFeesBySubmissionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ProducerFeesResponseDto?)null);
+
+            var result = await _service.GetFeesBySubmissionAsync(Guid.NewGuid(), CancellationToken.None);
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceThrowsServiceException_Rethrows()
+        {
+            var inner = new ServiceException("inner");
+            _httpProducerFeesService
+                .Setup(h => h.GetFeesBySubmissionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(inner);
+
+            Func<Task> act = async () => await _service.GetFeesBySubmissionAsync(Guid.NewGuid(), CancellationToken.None);
+
+            var thrown = await act.Should().ThrowAsync<ServiceException>();
+            thrown.Which.Should().BeSameAs(inner);
+        }
+
+        [TestMethod]
+        public async Task GetFeesBySubmissionAsync_HttpServiceThrowsUnexpected_WrapsInServiceException()
+        {
+            _httpProducerFeesService
+                .Setup(h => h.GetFeesBySubmissionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("oops"));
+
+            Func<Task> act = async () => await _service.GetFeesBySubmissionAsync(Guid.NewGuid(), CancellationToken.None);
+
+            await act.Should().ThrowAsync<ServiceException>()
+                .WithMessage(ExceptionMessages.ErrorCalculatingProducerFees);
+        }
     }
 }

--- a/src/EPR.Payment.Facade/Controllers/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesController.cs
+++ b/src/EPR.Payment.Facade/Controllers/RegistrationFees/ComplianceScheme/ComplianceSchemeFeesController.cs
@@ -94,5 +94,45 @@ namespace EPR.Payment.Facade.Controllers.RegistrationFees.ComplianceScheme
             }
         }
 
+        [ApiExplorerSettings(GroupName = "v1")]
+        [HttpGet("v1/compliance-scheme/registration-fee/{submissionId:guid}")]
+        [SwaggerOperation(
+            Summary = "Get compliance scheme fees for a stored submission",
+            Description = "Forwards to the payment service, which derives every input from the stored registration submission (latest non-rejected record and its event lifecycle) and returns the calculated fees."
+        )]
+        [SwaggerResponse(200, "Returns the calculated fees", typeof(ComplianceSchemeFeesResponseDto))]
+        [SwaggerResponse(404, "No non-rejected registration submission found for this submissionId")]
+        [SwaggerResponse(500, "Internal server error occurred while calculating fees")]
+        [ProducesResponseType(typeof(ComplianceSchemeFeesResponseDto), 200)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _complianceSchemeFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+                return result is null ? NotFound() : Ok(result);
+            }
+            catch (ServiceException ex)
+            {
+                _logger.LogError(ex, LogMessages.ErrorOccuredWhileCalculatingComplianceSchemeFees, nameof(GetFeesBySubmissionAsync));
+                return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+                {
+                    Title = "Service Error",
+                    Detail = ex.Message,
+                    Status = StatusCodes.Status500InternalServerError
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, LogMessages.ErrorOccuredWhileCalculatingComplianceSchemeFees, nameof(GetFeesBySubmissionAsync));
+                return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+                {
+                    Title = "Unexpected Error",
+                    Detail = ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees,
+                    Status = StatusCodes.Status500InternalServerError
+                });
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade/Controllers/RegistrationFees/Producer/ProducersFeesController.cs
+++ b/src/EPR.Payment.Facade/Controllers/RegistrationFees/Producer/ProducersFeesController.cs
@@ -94,6 +94,45 @@ namespace EPR.Payment.Facade.Controllers.RegistrationFees.Producer
             }
         }
 
-
+        [ApiExplorerSettings(GroupName = "v1")]
+        [HttpGet("v1/producer/registration-fee/{submissionId:guid}")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ProducerFeesResponseDto))]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
+        [SwaggerOperation(
+            Summary = "Get producer registration fees for a stored submission",
+            Description = "Forwards to the payment service, which derives every input from the stored registration submission (latest non-rejected record and its event lifecycle) and returns the calculated fees."
+        )]
+        [SwaggerResponse(StatusCodes.Status200OK, "Returns the calculated fees for the producer.", typeof(ProducerFeesResponseDto))]
+        [SwaggerResponse(StatusCodes.Status404NotFound, "No non-rejected registration submission found for this submissionId.")]
+        [SwaggerResponse(StatusCodes.Status500InternalServerError, "If an unexpected error occurs.", typeof(ProblemDetails))]
+        public async Task<IActionResult> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _producerFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+                return result is null ? NotFound() : Ok(result);
+            }
+            catch (ServiceException ex)
+            {
+                _logger.LogError(ex, LogMessages.ErrorOccuredWhileCalculatingProducerFees, nameof(GetFeesBySubmissionAsync));
+                return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+                {
+                    Title = "Service Error",
+                    Detail = ex.Message,
+                    Status = StatusCodes.Status500InternalServerError
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, LogMessages.ErrorOccuredWhileCalculatingProducerFees, nameof(GetFeesBySubmissionAsync));
+                return StatusCode(StatusCodes.Status500InternalServerError, new ProblemDetails
+                {
+                    Title = "Unexpected Error",
+                    Detail = ExceptionMessages.UnexpectedErrorCalculatingProducerFees,
+                    Status = StatusCodes.Status500InternalServerError
+                });
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade/Services/RegistrationFees/ComplianceScheme/ComplianceSchemeCalculatorService.cs
+++ b/src/EPR.Payment.Facade/Services/RegistrationFees/ComplianceScheme/ComplianceSchemeCalculatorService.cs
@@ -40,5 +40,21 @@ namespace EPR.Payment.Facade.Services.RegistrationFees.ComplianceScheme
             }
         }
 
+        public async Task<ComplianceSchemeFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _httpComplianceSchemeFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+            }
+            catch (ServiceException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, ExceptionMessages.UnexpectedErrorCalculatingComplianceSchemeFees);
+                throw new ServiceException(ExceptionMessages.ErrorCalculatingComplianceSchemeFees, ex);
+            }
+        }
     }
 }

--- a/src/EPR.Payment.Facade/Services/RegistrationFees/ComplianceScheme/Interfaces/IComplianceSchemeCalculatorService.cs
+++ b/src/EPR.Payment.Facade/Services/RegistrationFees/ComplianceScheme/Interfaces/IComplianceSchemeCalculatorService.cs
@@ -6,5 +6,7 @@ namespace EPR.Payment.Facade.Services.RegistrationFees.ComplianceScheme.Interfac
     public interface IComplianceSchemeCalculatorService
     {
         Task<ComplianceSchemeFeesResponseDto> CalculateFeesAsync(ComplianceSchemeFeesRequestDto request, CancellationToken cancellationToken = default);
+
+        Task<ComplianceSchemeFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EPR.Payment.Facade/Services/RegistrationFees/Producer/Interfaces/IProducerFeesService.cs
+++ b/src/EPR.Payment.Facade/Services/RegistrationFees/Producer/Interfaces/IProducerFeesService.cs
@@ -6,5 +6,7 @@ namespace EPR.Payment.Facade.Services.RegistrationFees.Producer.Interfaces
     public interface IProducerFeesService
     {
         Task<ProducerFeesResponseDto> CalculateProducerFeesAsync(ProducerFeesRequestDto request, CancellationToken cancellationToken = default);
+
+        Task<ProducerFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EPR.Payment.Facade/Services/RegistrationFees/Producer/ProducerFeesService.cs
+++ b/src/EPR.Payment.Facade/Services/RegistrationFees/Producer/ProducerFeesService.cs
@@ -48,5 +48,21 @@ namespace EPR.Payment.Facade.Services.RegistrationFees.Producer
             }
         }
 
+        public async Task<ProducerFeesResponseDto?> GetFeesBySubmissionAsync(Guid submissionId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _httpProducerFeesService.GetFeesBySubmissionAsync(submissionId, cancellationToken);
+            }
+            catch (ServiceException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, ExceptionMessages.UnexpectedErrorCalculatingProducerFees);
+                throw new ServiceException(ExceptionMessages.ErrorCalculatingProducerFees, ex);
+            }
+        }
     }
 }


### PR DESCRIPTION
Support changes to allow fees to be fully served by epr-payment-service
Return RegistrationBlobName on fees responses to indicated the CSV that the fees relate to (for UI edge case validation)